### PR TITLE
Layout for user cards, added an expand button for every user card.

### DIFF
--- a/src/Components/User.css
+++ b/src/Components/User.css
@@ -1,0 +1,31 @@
+.userCard {
+    display: grid;
+    grid-template-columns: 100px 4fr 1fr;
+    width: 1000px;
+    margin: 0 auto;
+}
+
+.userCardButton button {
+    margin-top: 25px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 24px;
+}
+
+.action-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+.action-button:hover {
+    background-color: black;
+    color: white;
+}
+
+.expandedInfo{
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}

--- a/src/Components/User.js
+++ b/src/Components/User.js
@@ -1,11 +1,32 @@
+import { useState } from 'react';
+import './User.css'
 export default function User({ user }) {
+    const [expanded, setExpanded] = useState(false);
+    const handleExpand = () => {
+        setExpanded(!expanded)
+    }
     return (
-        <div>
-            <h3>{user.first_name} {user.last_name}</h3>
-            <h4>{user.joined_at}</h4>
-            <p><small>Joined: {new Date(user.joined_at).toLocaleDateString()}</small></p>
-            <button>Remove</button>
-            <button>Change Role</button>
+        <div className='userCard'>
+            <div className='userCardImg'>
+                {/* <img alt='' src={user.img} /> add user img in backend  */}
+            </div>
+            <div className='userCardInfo'>
+                <h3>{user.first_name} {user.last_name}</h3>
+                <p><small>Joined: {new Date(user.joined_at).toLocaleDateString()}</small></p>
+                {expanded && (
+                    <div className='expandedInfo'>
+                        <p>{user.email}</p>
+                        <div>
+                            <button className='action-button'>Chat</button>
+                            <button className='action-button'>Change Role</button>
+                            <button className='action-button'>Remove</button>
+                        </div>
+                    </div>
+                )}
+            </div>
+            <div className='userCardButton'>
+                <button onClick={handleExpand}>{expanded ? "-" : "+"} </button>
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
Users can expand users card to check for more info and to chat. "Change Role" and "Remove" buttons for admins when card is expanded.

Added:
- Changed the 1st draft layout for each user card.
- Added expanding button to check additional user info and show a chat option.
- Improved styling

Future Implementations:
- Add profile images using firebase storage.
- Add more data in the backend for users to show in the expanded window.
- Adding a "Expand All/ Collapse All" button to quickly close all cards Will have to change location of `const [expanded, setExpanded] = useState(false);)` to reduce state redundancy & create a synchronicity.