### PR TITLE
Lift expand state

### DIFF
--- a/src/Components/User.js
+++ b/src/Components/User.js
@@ -1,10 +1,7 @@
 import { useState } from 'react';
 import './User.css'
-export default function User({ user }) {
-    const [expanded, setExpanded] = useState(false);
-    const handleExpand = () => {
-        setExpanded(!expanded)
-    }
+export default function User({ user, expanded, onClick }) {
+
     return (
         <div className='userCard'>
             <div className='userCardImg'>
@@ -25,7 +22,7 @@ export default function User({ user }) {
                 )}
             </div>
             <div className='userCardButton'>
-                <button onClick={handleExpand}>{expanded ? "-" : "+"} </button>
+                <button onClick={onClick}>{expanded ? "-" : "+"} </button>
             </div>
         </div>
     )

--- a/src/Components/User.js
+++ b/src/Components/User.js
@@ -1,7 +1,5 @@
-import { useState } from 'react';
 import './User.css'
 export default function User({ user, expanded, onClick }) {
-
     return (
         <div className='userCard'>
             <div className='userCardImg'>

--- a/src/Components/UsersList.js
+++ b/src/Components/UsersList.js
@@ -78,6 +78,8 @@ export default function UsersList({ users }) {
                         <option value="name">name</option>
                         <option value="email">email</option>
                     </select>
+                    <button onClick={toggleExpandAll}>Expand All</button>
+                    <button onClick={toggleCollapseAll}>Collaspe All</button>
 
                 </div>
                 <div className=''>{renderContent()}</div>

--- a/src/Components/UsersList.js
+++ b/src/Components/UsersList.js
@@ -4,6 +4,22 @@ import User from "./User"
 export default function UsersList({ users }) {
     const [searchInput, setSearchInput] = useState("");
     const [sortKey, setSortKey] = useState("id");
+    const [expanded, setExpanded] = useState([]);
+
+    const toggleExpanded = (id) => {
+        if (expanded.includes(id)) {
+            setExpanded(expanded.filter((currId) => currId !== id));
+        } else {
+            setExpanded([...expanded, id]);
+        }
+    }
+    const toggleExpandAll = () => {
+        const expandAll = users.map((user) => user.id);
+        setExpanded(expandAll);
+    };
+    const toggleCollapseAll = () => {
+        setExpanded([]);
+    };
 
     const handleChange = (e) => {
         setSearchInput(e.target.value);
@@ -41,7 +57,8 @@ export default function UsersList({ users }) {
             return <div className="NoContent">No results for {searchInput} </div>;
         }
         return usersToDisplay.map((user) => (
-            <User key={user.id} user={user} />
+            <User key={user.id} user={user} expanded={expanded.includes(user.id)}
+                onClick={() => toggleExpanded(user.id)} />
         ));
     };
 


### PR DESCRIPTION
Lifted expand states to reduce redundancy.

Added:

- Expanded states lifted to UserList to reduce the amount of states for each card to 0.
- Added a toggle all / collapse all for users to easily open every card that is shown.
- Expanded states use an array of IDs to see which card is "expanded" rather than a boolean.

Future implementations:

- Add a "view profile" button on cards to access each profile easily.
- Show "role" of user when expanded.
- Add an activity / last seen icon on users. 

